### PR TITLE
Fix issue where heartbeat wasn't being shutdown properly

### DIFF
--- a/python/lsst/dm/ATArchiver/atarchiver_csc.py
+++ b/python/lsst/dm/ATArchiver/atarchiver_csc.py
@@ -55,6 +55,7 @@ class ATArchiverCSC(dm_csc):
 
         self.director = ATDirector(self, "L1SystemCfg.yaml", "ATArchiverCSC.log")
 
+        self.current_state = None
         LOGGER.info("************************ Starting ATArchiver ************************")
 
     async def send_processingStatus(self, statusCode, description):
@@ -63,14 +64,77 @@ class ATArchiverCSC(dm_csc):
 
     def report_summary_state(self):
         super().report_summary_state()
-        if self.summary_state == State.STANDBY:
+
+        s_cur = None
+        if self.current_state is not None:
+            s_cur = self.state_to_str[self.current_state]
+        s_sum = self.state_to_str[self.summary_state]
+
+        LOGGER.info(f"current state is: {s_cur}; transition to {s_sum}")
+
+        # Services are started when transitioning from STANDBY to DISABLED.  Services
+        # are stopped when transitioning from DISABLED to STANDBY.   Services are always stopped
+        # when moving from any state to FAULT. The internal state machine in the base class only
+        # allows transition from FAULT to STANDBY.
+
+        # NOTE: The following can be optimized, but hasn't been to give a clearer picture
+        #       about which state transitions occur, and what happens when they do occur.
+
+        # if current_state hasn't been set, and the summary_state is STANDBY, we're just
+        # starting up, so don't do anything but set the current state to STANBY
+        if (self.current_state is None) and (self.summary_state == State.STANDBY):
+            self.current_state = State.STANDBY
+            return
+
+        # if going from STANDBY to DISABLED, start external services
+        if (self.current_state == State.STANDBY) and (self.summary_state == State.DISABLED):
+            asyncio.ensure_future(self.start_services())
+            self.current_state = State.DISABLED
+            return
+
+        # if going from DISABLED to STANDBY, stop external services
+        if (self.current_state == State.DISABLED) and (self.summary_state == State.STANDBY):
             asyncio.ensure_future(self.stop_services())
-        elif self.summary_state == State.FAULT:
-            asyncio.ensure_future(self.stop_services())
+            self.current_state = State.STANDBY
+            return
 
 
-    async def begin_start(self, data):
-    #async def start_services(self):
+        # if going from STANDBY to FAULT, kill any external services that started
+        if (self.current_state == State.STANDBY) and (self.summary_state == State.FAULT):
+            asyncio.ensure_future(self.stop_services())
+            self.current_state = State.FAULT
+            return
+
+        # if going from ENABLED to FAULT, don't do anything, so we can debug
+        if (self.current_state == State.ENABLED) and (self.summary_state == State.FAULT):
+            asyncio.ensure_future(self.stop_services())
+            self.current_state = State.FAULT
+            return
+
+        # if going from DISABLED to FAULT, don't do anything, so we can debug
+        if (self.current_state == State.DISABLED) and (self.summary_state == State.FAULT):
+            asyncio.ensure_future(self.stop_services())
+            self.current_state = State.FAULT
+            return
+
+        # These are all place holders and only update state
+
+        # if going from FAULT to STANDBY, services have already been stopped
+        if (self.current_state == State.FAULT) and (self.summary_state == State.STANDBY):
+            self.current_state = State.STANDBY
+            return
+
+        # if going from DISABLED to ENABLED leave external services alone, but accept control commands
+        if (self.current_state == State.DISABLED) and (self.summary_state == State.ENABLED):
+            self.current_state = State.ENABLED
+            return
+
+        # if going from ENABLED to DISABLED, leave external services alone, but reject control commands
+        if (self.current_state == State.ENABLED) and (self.summary_state == State.DISABLED):
+            self.current_state = State.DISABLED
+            return
+
+    async def start_services(self):
         await self.director.start_services()
 
     async def stop_services(self):


### PR DESCRIPTION
Implementing this via do_* methods caused issues when faults occurred. (Calling "do_start" and then having a fault occur would transition to fault state, then go to disabled, which shouldn't happen).

Implemented transition states via report_summary_state, as suggested by rowen to fix this.