### PR TITLE
Fix issue where event is not put into the event cache.

### DIFF
--- a/python/lsst/dm/ATArchiver/atdirector.py
+++ b/python/lsst/dm/ATArchiver/atdirector.py
@@ -125,8 +125,6 @@ class ATDirector(Director):
 
         self.archive_heartbeat_task = None
 
-        self.association_evt = asyncio.Event()
-
         self.startIntegration_evt = asyncio.Event()
         self.new_at_archive_item_evt = asyncio.Event()
         self.endReadout_evt = asyncio.Event()
@@ -192,7 +190,6 @@ class ATDirector(Director):
         if self.services_started_evt.is_set():
             self.stop_watcher_evt.set()
             self.stop_forwarder_beacon_evt.set()
-            self.association_evt.clear()
             await self.rescind_connections()
             self.services_started_evt.clear()
 

--- a/python/lsst/dm/ATArchiver/atdirector.py
+++ b/python/lsst/dm/ATArchiver/atdirector.py
@@ -333,7 +333,7 @@ class ATDirector(Director):
         code = 5752
         report = f"No association response from forwarder. Setting fault state with code = {code}"
 
-        evt = self.association_evt
+        evt = await self.create_event(ack_id)
         waiter = Waiter(evt, self.parent, self.ack_timeout)
         self.startIntegration_ack_task = asyncio.create_task(waiter.pause(code, report))
         
@@ -444,7 +444,8 @@ class ATDirector(Director):
                 LOGGER.info(f"Association ACK {ack_id} is unknown.  Ignored.")
                 return
         else:
-            self.association_evt.clear()
+            LOGGER.info("Missing ACK_ID in association message.")
+            return
         
         watcher = Watcher(self.stop_watcher_evt, self.parent, self.scoreboard)
         watcher_task = asyncio.create_task(watcher.peek(msg['ASSOCIATION_KEY'], self.seconds_to_expire))


### PR DESCRIPTION
This caused a failure when the ack_id can't be found when message was received.